### PR TITLE
Fixes played time error on first character load

### DIFF
--- a/modules/CB_PlayedTime.lua
+++ b/modules/CB_PlayedTime.lua
@@ -1,4 +1,4 @@
-﻿-- a LDB object that will show/hide the chocolatebar set in the chocolatebar options
+-- a LDB object that will show/hide the chocolatebar set in the chocolatebar options
 local LibStub = LibStub
 local L = LibStub("AceLocale-3.0"):GetLocale("ChocolateBar")
 local acetimer = LibStub("AceTimer-3.0")
@@ -63,7 +63,10 @@ function dataobj:OnTooltipShow()
 end
 
 local function getPlayerIdentifier()
-  local _, engClass, _, _, _, name, server = GetPlayerInfoByGUID(UnitGUID("player"))
+    local _, engClass, _, _, _, name, server = GetPlayerInfoByGUID(UnitGUID("player"))
+	if not name then
+		return
+	end
 	if not server or server == "" then
 		server = GetNormalizedRealmName() or ""
 	end
@@ -75,8 +78,12 @@ local function GetMaxLevelForPlayerExpansion()
 end
 
 local function playedTimeEvent(self, event, totalTimeInSeconds, timeAtThisLevel)
-	if not db[getPlayerIdentifier()] then db[getPlayerIdentifier()] = {} end
-	local dbChar = db[getPlayerIdentifier()]
+	local playerIdentifier = getPlayerIdentifier()
+	if not playerIdentifier then
+		return
+	end
+	if not db[playerIdentifier] then db[playerIdentifier] = {} end
+	local dbChar = db[playerIdentifier]
 	local days = totalTimeInSeconds / 3600 / 24
 	dbChar.total = totalTimeInSeconds
 	if UnitLevel("player") == GetMaxLevelForPlayerExpansion() then


### PR DESCRIPTION
Fixes #15 

stops handling TIME_PLAYED_MSG if we don't know the player's name yet
seems to occur in retail on first character load (not subsequent reloads or character change)

I've been seeing the same stack trace as mentioned in #15 since 9.2 release and this seems to fix it, and still let the played time get tracked on subsequent events.