### PR TITLE
Fixes reference to GetAddOnMetadata for 11.0.2

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -6,7 +6,7 @@ local select, strjoin, CreateFrame = select, strjoin, CreateFrame
 
 local _, _, _, tocversion = GetBuildInfo()
 
-local addonVersion = GetAddOnMetadata("ChocolateBar", "Version")
+local addonVersion = C_AddOns.GetAddOnMetadata("ChocolateBar", "Version")
 
 ChocolateBar.Jostle = {}
 ChocolateBar.Jostle2 = {}
@@ -278,7 +278,7 @@ end
 
 function ChocolateBar:isNewInstall()
 	local lastversion = ChocolateBarDB.addonVersion or ""
-	return lastversion < GetAddOnMetadata("ChocolateBar", "Version") and true or false
+	return lastversion < C_AddOns.GetAddOnMetadata("ChocolateBar", "Version") and true or false
 end
 
 function ChocolateBar:ToggleOrderHallCommandBar()

--- a/Options.lua
+++ b/Options.lua
@@ -9,7 +9,7 @@ local LSM = LibStub("LibSharedMedia-3.0")
 local _G, pairs, string = _G, pairs, string
 local db, moreChocolate
 local index = 0
-local version = GetAddOnMetadata("ChocolateBar","X-Curse-Packaged-Version") or ""
+local version = C_AddOns.GetAddOnMetadata("ChocolateBar","X-Curse-Packaged-Version") or ""
 
 local function GetStats(info)
 	local total = 0
@@ -1556,8 +1556,8 @@ function ChocolateBar:AddObjectOptions(name,obj)
 	if t ~= "data source" and t ~= "launcher" then
 		return
 	end
-	--local curse = GetAddOnMetadata(name,"X-Curse-Packaged-Version") or ""
-	--local version = GetAddOnMetadata(name,"Version") or ""
+	--local curse = C_AddOns.GetAddOnMetadata(name,"X-Curse-Packaged-Version") or ""
+	--local version = C_AddOns.GetAddOnMetadata(name,"Version") or ""
 
 	t = t or "not set"
 	local cleanName


### PR DESCRIPTION
These can be seen on first login with ChocolateBar installed after 11.0.2 was applied. These changes have fixed them for me and survived a basic smoke test of the addon.

Should fix #39 and #40, though as cremor points out below, there's also a fix needed in modules\MicroMenu\Options.lua